### PR TITLE
Lazy-load RecBole training helper import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# KuaiRec SASRec Training Pipeline
+
+This repository contains utilities to convert the [KuaiRec](https://kuairec.com/) dataset into [RecBole](https://recbole.io/) atomic files and to train the sequential recommender **SASRec** on top of them.
+
+## 1. Prepare the dataset
+
+1. Download and extract `KuaiRec.zip` so that the directory layout matches
+   `KuaiRec/data/{small_matrix.csv,big_matrix.csv,user_features.csv,...}`.
+2. Run the converter to materialise RecBole atomic files (`.inter`, `.user`, `.item`):
+
+   ```bash
+   python -m kuairec_pipeline.data_prep /path/to/KuaiRec/data \
+       --output-dir data --dataset-name kuairec_small --matrix-size small \
+       --with-side-info --min-watch-ratio 0.1
+   ```
+
+   *Use `--matrix-size big` to consume `big_matrix.csv`. Omitting `--with-side-info`
+   generates only the interaction file.*
+
+## 2. Train SASRec with RecBole
+
+Once the RecBole-formatted files are available in `data/kuairec_small/` the
+training entry point can be launched with:
+
+```bash
+python -m kuairec_pipeline.train_sasrec \
+    --data-path data --dataset-name kuairec_small \
+    --output-dir saved --epochs 100 --learning-rate 0.001
+```
+
+The command uses the baseline hyperparameters defined in
+`configs/kuairec_sasrec.yaml`. Any parameter exposed by RecBole can be overridden
+on the command line, e.g.:
+
+```bash
+python -m kuairec_pipeline.train_sasrec --learning-rate 0.0005 --neg-samples 5
+```
+
+## 3. Python environment
+
+Install the Python dependencies in a virtual environment (Python ≥ 3.9):
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+`RecBole` will automatically pull the matching version of PyTorch. If GPU training
+is required ensure a compatible CUDA wheel of PyTorch is installed before running
+`pip install recbole`.
+
+## 4. Outputs
+
+- `data/<dataset_name>/<dataset_name>.inter`: sequential interactions sorted by
+  timestamp with watch/play metadata.
+- `data/<dataset_name>/<dataset_name>.user`: optional user side features (if
+  `--with-side-info` is passed).
+- `data/<dataset_name>/<dataset_name>.item`: optional item features summarising
+  the latest per-video statistics.
+- `saved/`: RecBole checkpoints and logs for the SASRec training run.
+
+## 5. Reproducing experiments
+
+For reproducibility the default config enforces deterministic behaviour via
+`seed: 2020` and `reproducibility: true`. Adjust `device: cpu` to `cuda` when
+running on GPUs.

--- a/configs/kuairec_sasrec.yaml
+++ b/configs/kuairec_sasrec.yaml
@@ -1,0 +1,59 @@
+# Baseline configuration for training RecBole's SASRec on KuaiRec interactions.
+field_separator: "\t"
+model: SASRec
+dataset: kuairec_small
+data_path: data
+USER_ID_FIELD: user_id
+ITEM_ID_FIELD: item_id
+TIME_FIELD: timestamp
+load_col:
+  inter: [user_id, item_id, timestamp, label, watch_ratio, play_duration, video_duration]
+# Uncomment the following when side information files are generated.
+#  user: [user_id, user_active_degree, is_lowactive_period, is_live_streamer, is_video_author,
+#         follow_user_num, fans_user_num, friend_user_num, register_days, follow_user_num_range,
+#         fans_user_num_range, friend_user_num_range, register_days_range,
+#         onehot_feat0, onehot_feat1, onehot_feat2, onehot_feat3, onehot_feat4, onehot_feat5,
+#         onehot_feat6, onehot_feat7, onehot_feat8, onehot_feat9, onehot_feat10, onehot_feat11,
+#         onehot_feat12, onehot_feat13, onehot_feat14, onehot_feat15, onehot_feat16, onehot_feat17]
+#  item: [item_id, author_id, video_type, upload_type, video_duration, video_width, video_height,
+#         music_id, video_tag_id, show_cnt, show_user_num, play_cnt, play_user_num, play_duration,
+#         complete_play_cnt, valid_play_cnt, long_time_play_cnt, short_time_play_cnt,
+#         play_progress, like_cnt, comment_cnt, follow_cnt, share_cnt, download_cnt, tags]
+
+# Sequential recommendation evaluation protocol.
+eval_args:
+  split: {"RS": [0.8, 0.1, 0.1]}
+  group_by: user
+  order: TO
+  mode: full
+
+metrics: [Recall, NDCG, MRR]
+topk: [5, 10, 20]
+valid_metric: Recall@10
+metric_decimal_place: 4
+
+# Training hyper-parameters.
+epochs: 100
+learning_rate: 0.001
+train_batch_size: 2048
+eval_batch_size: 4096
+neg_sampling:
+  uniform: 1
+
+# SASRec architecture.
+MAX_ITEM_LIST_LENGTH: 200
+hidden_size: 128
+inner_size: 256
+n_layers: 2
+n_heads: 2
+hidden_dropout_prob: 0.2
+attn_dropout_prob: 0.2
+initializer_range: 0.02
+loss_type: CE
+
+# Reproducibility & logging.
+seed: 2020
+reproducibility: true
+device: cpu
+log_wandb: false
+checkpoint_dir: saved

--- a/kuairec_pipeline/__init__.py
+++ b/kuairec_pipeline/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities to prepare and train KuaiRec sequential recommenders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .data_prep import build_interaction_file, prepare_kuairec_dataset  # noqa: F401
+
+__all__ = ["build_interaction_file", "prepare_kuairec_dataset", "train_model"]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose training helpers to avoid importing RecBole eagerly."""
+
+    if name == "train_model":
+        from .train_sasrec import train_model as _train_model
+
+        return _train_model
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/kuairec_pipeline/data_prep.py
+++ b/kuairec_pipeline/data_prep.py
@@ -1,0 +1,364 @@
+"""Utilities to convert the KuaiRec dataset into RecBole atomic files."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Schema definition for RecBole atomic files."""
+
+    name: str
+    dtype: str
+    kind: str
+    required: bool = False
+
+
+INTERACTION_SCHEMA: Sequence[FieldSpec] = (
+    FieldSpec("user_id", "token", "token", required=True),
+    FieldSpec("item_id", "token", "token", required=True),
+    FieldSpec("timestamp", "float", "numeric", required=True),
+    FieldSpec("label", "float", "numeric"),
+    FieldSpec("watch_ratio", "float", "numeric"),
+    FieldSpec("play_duration", "float", "numeric"),
+    FieldSpec("video_duration", "float", "numeric"),
+)
+
+USER_SCHEMA: Sequence[FieldSpec] = (
+    FieldSpec("user_id", "token", "token", required=True),
+    FieldSpec("user_active_degree", "token", "token"),
+    FieldSpec("is_lowactive_period", "float", "numeric"),
+    FieldSpec("is_live_streamer", "float", "numeric"),
+    FieldSpec("is_video_author", "float", "numeric"),
+    FieldSpec("follow_user_num", "float", "numeric"),
+    FieldSpec("fans_user_num", "float", "numeric"),
+    FieldSpec("friend_user_num", "float", "numeric"),
+    FieldSpec("register_days", "float", "numeric"),
+    FieldSpec("follow_user_num_range", "token", "token"),
+    FieldSpec("fans_user_num_range", "token", "token"),
+    FieldSpec("friend_user_num_range", "token", "token"),
+    FieldSpec("register_days_range", "token", "token"),
+    *[
+        FieldSpec(f"onehot_feat{idx}", "token", "token")
+        for idx in range(18)
+    ],
+)
+
+ITEM_SCHEMA: Sequence[FieldSpec] = (
+    FieldSpec("item_id", "token", "token", required=True),
+    FieldSpec("author_id", "token", "token"),
+    FieldSpec("video_type", "token", "token"),
+    FieldSpec("upload_type", "token", "token"),
+    FieldSpec("video_duration", "float", "numeric"),
+    FieldSpec("video_width", "float", "numeric"),
+    FieldSpec("video_height", "float", "numeric"),
+    FieldSpec("music_id", "token", "token"),
+    FieldSpec("video_tag_id", "token", "token"),
+    FieldSpec("show_cnt", "float", "numeric"),
+    FieldSpec("show_user_num", "float", "numeric"),
+    FieldSpec("play_cnt", "float", "numeric"),
+    FieldSpec("play_user_num", "float", "numeric"),
+    FieldSpec("play_duration", "float", "numeric"),
+    FieldSpec("complete_play_cnt", "float", "numeric"),
+    FieldSpec("valid_play_cnt", "float", "numeric"),
+    FieldSpec("long_time_play_cnt", "float", "numeric"),
+    FieldSpec("short_time_play_cnt", "float", "numeric"),
+    FieldSpec("play_progress", "float", "numeric"),
+    FieldSpec("like_cnt", "float", "numeric"),
+    FieldSpec("comment_cnt", "float", "numeric"),
+    FieldSpec("follow_cnt", "float", "numeric"),
+    FieldSpec("share_cnt", "float", "numeric"),
+    FieldSpec("download_cnt", "float", "numeric"),
+    FieldSpec("tags", "token_seq", "token_seq"),
+)
+
+DEFAULT_MATRIX = "small"
+
+
+def _sanitize_numeric(series: pd.Series, fill_value: float = 0.0) -> pd.Series:
+    coerced = pd.to_numeric(series, errors="coerce")
+    return coerced.fillna(fill_value).astype(float)
+
+
+def _sanitize_token(series: pd.Series, fill_value: str = "UNKNOWN") -> pd.Series:
+    return series.fillna(fill_value).astype(str)
+
+
+def _sanitize_token_seq(series: pd.Series) -> pd.Series:
+    def _convert(value: object) -> str:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return ""
+        if isinstance(value, list):
+            parts = value
+        else:
+            text = str(value).strip()
+            if not text:
+                return ""
+            try:
+                parsed = ast.literal_eval(text)
+            except (ValueError, SyntaxError):
+                parsed = [token.strip() for token in text.replace("[", "").replace("]", "").split(",") if token.strip()]
+            parts = parsed if isinstance(parsed, list) else [parsed]
+        return " ".join(str(part) for part in parts if str(part))
+
+    return series.map(_convert)
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _write_atomic_file(df: pd.DataFrame, schema: Sequence[FieldSpec], destination: Path) -> int:
+    available_fields = [field for field in schema if field.name in df.columns]
+    missing_required = [field.name for field in schema if field.required and field.name not in df.columns]
+    if missing_required:
+        raise ValueError(f"Missing required columns: {missing_required}")
+    if not available_fields:
+        raise ValueError("No columns available to write to atomic file.")
+
+    processors = {
+        "numeric": _sanitize_numeric,
+        "token": _sanitize_token,
+        "token_seq": _sanitize_token_seq,
+    }
+
+    processed = {}
+    for field in available_fields:
+        processor = processors.get(field.kind)
+        if processor is None:
+            raise KeyError(f"Unsupported field kind: {field.kind}")
+        processed[field.name] = processor(df[field.name])
+
+    ordered_columns = [field.name for field in available_fields]
+    header = "\t".join(f"{field.name}:{field.dtype}" for field in available_fields)
+
+    _ensure_parent_dir(destination)
+    with destination.open("w", encoding="utf-8") as fp:
+        fp.write(header + "\n")
+        processed_df = pd.DataFrame(processed)
+        processed_df.to_csv(fp, sep="\t", index=False, header=False)
+    logging.info("Wrote %d rows to %s", len(processed_df), destination)
+    return len(processed_df)
+
+
+def build_interaction_file(
+    matrix_path: Path,
+    output_path: Path,
+    *,
+    chunk_size: int = 1_000_000,
+    min_watch_ratio: Optional[float] = None,
+) -> Dict[str, int]:
+    """Convert a KuaiRec interaction matrix into a RecBole ``.inter`` file."""
+
+    if not matrix_path.exists():
+        raise FileNotFoundError(matrix_path)
+
+    logging.info("Building interaction file from %s", matrix_path)
+    _ensure_parent_dir(output_path)
+
+    header = "\t".join(f"{field.name}:{field.dtype}" for field in INTERACTION_SCHEMA)
+    with output_path.open("w", encoding="utf-8") as fp:
+        fp.write(header + "\n")
+
+    total_rows = 0
+    users: set[int] = set()
+    items: set[int] = set()
+
+    for chunk in pd.read_csv(matrix_path, chunksize=chunk_size):
+        chunk = chunk.rename(columns={"video_id": "item_id"})
+        columns = {
+            "user_id": pd.to_numeric(chunk["user_id"], errors="coerce"),
+            "item_id": pd.to_numeric(chunk["item_id"], errors="coerce"),
+            "timestamp": pd.to_numeric(chunk["timestamp"], errors="coerce"),
+            "watch_ratio": pd.to_numeric(chunk.get("watch_ratio"), errors="coerce"),
+            "play_duration": pd.to_numeric(chunk.get("play_duration"), errors="coerce"),
+            "video_duration": pd.to_numeric(chunk.get("video_duration"), errors="coerce"),
+        }
+        frame = pd.DataFrame(columns)
+        frame = frame.dropna(subset=["user_id", "item_id", "timestamp"])
+        if min_watch_ratio is not None:
+            frame = frame[frame["watch_ratio"].fillna(0.0) >= min_watch_ratio]
+        if frame.empty:
+            continue
+        frame["user_id"] = frame["user_id"].astype(int)
+        frame["item_id"] = frame["item_id"].astype(int)
+        frame["timestamp"] = frame["timestamp"].astype(float)
+        frame["label"] = 1.0
+        frame["watch_ratio"] = frame["watch_ratio"].fillna(0.0).astype(float)
+        frame["play_duration"] = frame["play_duration"].fillna(0.0).astype(float)
+        frame["video_duration"] = frame["video_duration"].fillna(0.0).astype(float)
+
+        frame = frame.sort_values(["user_id", "timestamp"], kind="mergesort")
+
+        users.update(frame["user_id"].unique().tolist())
+        items.update(frame["item_id"].unique().tolist())
+        total_rows += len(frame)
+
+        frame = frame[[field.name for field in INTERACTION_SCHEMA]]
+        frame.to_csv(
+            output_path,
+            mode="a",
+            sep="\t",
+            header=False,
+            index=False,
+            float_format="%.6f",
+        )
+
+    logging.info(
+        "Finished writing %d interactions covering %d users and %d items",
+        total_rows,
+        len(users),
+        len(items),
+    )
+    return {"n_interactions": total_rows, "n_users": len(users), "n_items": len(items)}
+
+
+def _load_latest_item_daily_features(path: Path) -> pd.DataFrame:
+    daily = pd.read_csv(path)
+    if "date" in daily.columns:
+        daily = daily.sort_values(["video_id", "date"], ascending=[True, False])
+        daily = daily.drop_duplicates("video_id", keep="first")
+    return daily
+
+
+def _build_user_file(source_dir: Path, dataset_dir: Path, dataset_name: str) -> Optional[int]:
+    user_path = source_dir / "user_features.csv"
+    if not user_path.exists():
+        logging.warning("User feature file not found at %s; skipping", user_path)
+        return None
+    df = pd.read_csv(user_path)
+    destination = dataset_dir / f"{dataset_name}.user"
+    return _write_atomic_file(df, USER_SCHEMA, destination)
+
+
+def _build_item_file(source_dir: Path, dataset_dir: Path, dataset_name: str) -> Optional[int]:
+    daily_path = source_dir / "item_daily_features.csv"
+    categories_path = source_dir / "item_categories.csv"
+
+    if not daily_path.exists():
+        logging.warning("Item daily features not found at %s; skipping", daily_path)
+        return None
+
+    daily = _load_latest_item_daily_features(daily_path)
+    daily = daily.rename(columns={"video_id": "item_id"})
+
+    if categories_path.exists():
+        categories = pd.read_csv(categories_path)
+        categories = categories.rename(columns={"video_id": "item_id", "feat": "tags"})
+        categories["tags"] = _sanitize_token_seq(categories["tags"])
+        daily = daily.merge(categories[["item_id", "tags"]], on="item_id", how="left")
+    else:
+        logging.info("Item category file not found at %s; tags will be empty", categories_path)
+
+    destination = dataset_dir / f"{dataset_name}.item"
+    return _write_atomic_file(daily, ITEM_SCHEMA, destination)
+
+
+def prepare_kuairec_dataset(
+    source_data: Path,
+    output_dir: Path,
+    *,
+    dataset_name: str = "kuairec_small",
+    matrix_size: str = DEFAULT_MATRIX,
+    chunk_size: int = 1_000_000,
+    min_watch_ratio: Optional[float] = None,
+    include_side_info: bool = False,
+) -> Dict[str, Optional[int]]:
+    """Prepare RecBole atomic files for KuaiRec."""
+
+    matrix_filename = f"{matrix_size}_matrix.csv"
+    matrix_path = source_data / matrix_filename
+    dataset_dir = output_dir / dataset_name
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+
+    stats = build_interaction_file(
+        matrix_path,
+        dataset_dir / f"{dataset_name}.inter",
+        chunk_size=chunk_size,
+        min_watch_ratio=min_watch_ratio,
+    )
+
+    results: Dict[str, Optional[int]] = dict(stats)
+    if include_side_info:
+        results["n_user_rows"] = _build_user_file(source_data, dataset_dir, dataset_name)
+        results["n_item_rows"] = _build_item_file(source_data, dataset_dir, dataset_name)
+
+    logging.info("Dataset preparation summary: %s", results)
+    return results
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "source_data",
+        type=Path,
+        help="Path to the extracted KuaiRec `data` directory.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data"),
+        help="Directory to place the RecBole-formatted dataset (default: ./data)",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default="kuairec_small",
+        help="Name of the dataset folder/filename prefix to create.",
+    )
+    parser.add_argument(
+        "--matrix-size",
+        choices=["small", "big"],
+        default=DEFAULT_MATRIX,
+        help="Which interaction matrix to use (default: small).",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=1_000_000,
+        help="Number of rows to process per chunk when streaming the CSV.",
+    )
+    parser.add_argument(
+        "--min-watch-ratio",
+        type=float,
+        default=None,
+        help="Drop interactions whose watch_ratio is below this threshold.",
+    )
+    parser.add_argument(
+        "--with-side-info",
+        action="store_true",
+        help="Generate `.user` and `.item` side information files as well.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> Dict[str, Optional[int]]:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper(), format="[%(levelname)s] %(message)s")
+
+    return prepare_kuairec_dataset(
+        args.source_data,
+        args.output_dir,
+        dataset_name=args.dataset_name,
+        matrix_size=args.matrix_size,
+        chunk_size=args.chunk_size,
+        min_watch_ratio=args.min_watch_ratio,
+        include_side_info=args.with_side_info,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/kuairec_pipeline/train_sasrec.py
+++ b/kuairec_pipeline/train_sasrec.py
@@ -1,0 +1,175 @@
+"""Training entry-point for running RecBole's SASRec on KuaiRec."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+try:
+    from recbole.quick_start import run_recbole
+except ImportError as import_error:  # pragma: no cover - raised only if RecBole missing.
+    run_recbole = None  # type: ignore[assignment]
+    _IMPORT_ERROR = import_error
+else:
+    _IMPORT_ERROR = None
+
+DEFAULT_CONFIG = Path(__file__).resolve().parent.parent / "configs" / "kuairec_sasrec.yaml"
+
+
+def train_model(
+    *,
+    dataset: str,
+    data_path: Path,
+    config_file: Optional[Path] = DEFAULT_CONFIG,
+    model: str = "SASRec",
+    checkpoint_dir: Optional[Path] = None,
+    learning_rate: Optional[float] = None,
+    epochs: Optional[int] = None,
+    train_batch_size: Optional[int] = None,
+    eval_batch_size: Optional[int] = None,
+    seed: Optional[int] = None,
+    device: Optional[str] = None,
+    max_seq_length: Optional[int] = None,
+    neg_samples: Optional[int] = None,
+    extra_config: Optional[Dict[str, object]] = None,
+) -> Dict[str, object]:
+    """Launch a RecBole training run and return its reported metrics."""
+
+    if run_recbole is None:  # pragma: no cover - triggered only when dependency missing.
+        raise RuntimeError(
+            "RecBole is required to train the model. Install it with `pip install recbole`."
+        ) from _IMPORT_ERROR
+
+    overrides: Dict[str, object] = {
+        "data_path": str(data_path),
+        "dataset": dataset,
+    }
+    if checkpoint_dir is not None:
+        overrides["checkpoint_dir"] = str(checkpoint_dir)
+    if learning_rate is not None:
+        overrides["learning_rate"] = learning_rate
+    if epochs is not None:
+        overrides["epochs"] = epochs
+    if train_batch_size is not None:
+        overrides["train_batch_size"] = train_batch_size
+    if eval_batch_size is not None:
+        overrides["eval_batch_size"] = eval_batch_size
+    if seed is not None:
+        overrides["seed"] = seed
+    if device is not None:
+        overrides["device"] = device
+    if max_seq_length is not None:
+        overrides["MAX_ITEM_LIST_LENGTH"] = max_seq_length
+    if neg_samples is not None:
+        overrides["neg_sampling"] = {"uniform": neg_samples}
+    if extra_config:
+        overrides.update(extra_config)
+
+    config_files = [str(config_file)] if config_file else None
+    logging.info(
+        "Launching RecBole run with model=%s dataset=%s overrides=%s",
+        model,
+        dataset,
+        json.dumps(overrides, indent=2, sort_keys=True),
+    )
+    result = run_recbole(  # type: ignore[misc]
+        model=model,
+        dataset=dataset,
+        config_file_list=config_files,
+        config_dict=overrides,
+    )
+    logging.info("Training finished. Best validation metric: %s", result.get("best_valid_score"))
+    logging.info("Validation result: %s", result.get("valid_result"))
+    logging.info("Test result: %s", result.get("test_result"))
+    return result
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=Path("data"),
+        help="Directory containing RecBole atomic datasets (default: ./data).",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default="kuairec_small",
+        help="Dataset name to load from the data path (default: kuairec_small).",
+    )
+    parser.add_argument(
+        "--config-file",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help="RecBole YAML config file to use (default: configs/kuairec_sasrec.yaml).",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="SASRec",
+        help="RecBole model to train (default: SASRec).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("saved"),
+        help="Directory where checkpoints and logs will be stored.",
+    )
+    parser.add_argument("--learning-rate", type=float, default=None)
+    parser.add_argument("--epochs", type=int, default=None)
+    parser.add_argument("--train-batch-size", type=int, default=None)
+    parser.add_argument("--eval-batch-size", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument(
+        "--max-seq-length",
+        type=int,
+        default=None,
+        help="Override MAX_ITEM_LIST_LENGTH for SASRec.",
+    )
+    parser.add_argument(
+        "--neg-samples",
+        type=int,
+        default=None,
+        help="Number of negative samples per positive instance.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> Dict[str, object]:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper(), format="[%(levelname)s] %(message)s")
+
+    config_file = args.config_file if args.config_file and args.config_file.exists() else None
+    if args.config_file and not args.config_file.exists():
+        logging.warning("Config file %s does not exist; relying solely on CLI overrides", args.config_file)
+
+    result = train_model(
+        dataset=args.dataset_name,
+        data_path=args.data_path,
+        config_file=config_file,
+        model=args.model,
+        checkpoint_dir=args.output_dir,
+        learning_rate=args.learning_rate,
+        epochs=args.epochs,
+        train_batch_size=args.train_batch_size,
+        eval_batch_size=args.eval_batch_size,
+        seed=args.seed,
+        device=args.device,
+        max_seq_length=args.max_seq_length,
+        neg_samples=args.neg_samples,
+    )
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=1.5
+recbole>=1.2.0


### PR DESCRIPTION
## Summary
- lazily expose `train_model` from `kuairec_pipeline` so data-prep usage no longer imports RecBole and its heavy dependencies

## Testing
- python -m compileall kuairec_pipeline
- python -m kuairec_pipeline.data_prep --help


------
https://chatgpt.com/codex/tasks/task_e_68d0744436a08326a52c951e58d98698