### PR TITLE
Add top-K export utilities for SASRec training

### DIFF
--- a/kuairec_pipeline/train_sasrec.py
+++ b/kuairec_pipeline/train_sasrec.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import logging
+import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Sequence
+from typing import Any, Dict, Iterable, Optional, Sequence
 
 import numpy as np
+import torch.distributed as dist
 
 
 def _ensure_numpy_alias(name: str, target: object) -> None:
@@ -42,15 +46,310 @@ _ensure_numpy_alias("float_", np.float64)
 _ensure_numpy_alias("complex_", np.complex128)
 _ensure_numpy_alias("unicode_", np.str_)
 
-try:
-    from recbole.quick_start import run_recbole
+try:  # pragma: no cover - exercised only when RecBole is available.
+    from recbole.config import Config
+    from recbole.data import create_dataset, data_preparation
+    from recbole.data.transform import construct_transform
+    from recbole.utils import (
+        get_environment,
+        get_flops,
+        get_model,
+        get_trainer,
+        init_logger,
+        init_seed,
+        set_color,
+    )
+    from recbole.utils.case_study import full_sort_topk
 except ImportError as import_error:  # pragma: no cover - raised only if RecBole missing.
-    run_recbole = None  # type: ignore[assignment]
+    Config = None  # type: ignore[assignment]
+    create_dataset = None  # type: ignore[assignment]
+    data_preparation = None  # type: ignore[assignment]
+    construct_transform = None  # type: ignore[assignment]
+    get_environment = None  # type: ignore[assignment]
+    get_flops = None  # type: ignore[assignment]
+    get_model = None  # type: ignore[assignment]
+    get_trainer = None  # type: ignore[assignment]
+    init_logger = None  # type: ignore[assignment]
+    init_seed = None  # type: ignore[assignment]
+    set_color = None  # type: ignore[assignment]
+    full_sort_topk = None  # type: ignore[assignment]
     _IMPORT_ERROR = import_error
 else:
     _IMPORT_ERROR = None
 
 DEFAULT_CONFIG = Path(__file__).resolve().parent.parent / "configs" / "kuairec_sasrec.yaml"
+
+
+@dataclass
+class TrainingRun:
+    """Container bundling the RecBole artifacts produced during training."""
+
+    result: Dict[str, object]
+    config: Any
+    dataset: Any
+    train_data: Any
+    valid_data: Any
+    test_data: Any
+    trainer: Any
+
+
+def _is_rank_zero() -> bool:
+    """Return ``True`` when the current process should handle I/O side effects."""
+
+    if not dist.is_available():  # pragma: no cover - PyTorch without distributed support.
+        return True
+    if not dist.is_initialized():
+        return True
+    try:
+        return dist.get_rank() == 0
+    except RuntimeError:  # pragma: no cover - defensive for partially initialised process groups.
+        return True
+
+
+def _load_user_tokens(csv_path: Path) -> Sequence[str]:
+    """Parse ``user_id`` tokens from a CSV file."""
+
+    tokens: list[str] = []
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        try:
+            first_row = next(reader)
+        except StopIteration:
+            return tokens
+
+        header = [cell.strip() for cell in first_row]
+        header_lower = [cell.lower() for cell in header]
+        if "user_id" in header_lower:
+            user_idx = header_lower.index("user_id")
+        else:
+            user_idx = 0
+            if header and header[0]:
+                tokens.append(header[0])
+
+        for row in reader:
+            if len(row) <= user_idx:
+                continue
+            token = row[user_idx].strip()
+            if token:
+                tokens.append(token)
+
+    return tokens
+
+
+def _candidate_token_values(raw_token: Any) -> Sequence[Any]:
+    """Yield potential representations for a raw token value."""
+
+    candidates: list[Any] = []
+    if isinstance(raw_token, str):
+        stripped = raw_token.strip()
+        if not stripped:
+            return candidates
+        candidates.append(stripped)
+        try:
+            candidates.append(int(stripped))
+        except ValueError:
+            pass
+    else:
+        candidates.append(raw_token)
+        candidates.append(str(raw_token))
+
+    # Deduplicate while preserving order.
+    return list(dict.fromkeys(candidates))
+
+
+def _resolve_user_token(dataset: Any, token: Any) -> Optional[int]:
+    """Convert an external user token into its internal RecBole id."""
+
+    uid_field = dataset.uid_field
+    for candidate in _candidate_token_values(token):
+        try:
+            internal_id = dataset.token2id(uid_field, candidate)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(internal_id, np.ndarray):
+            if internal_id.size == 0:
+                continue
+            return int(internal_id.item())
+        return int(internal_id)
+    return None
+
+
+def _resolve_user_ids(dataset: Any, test_data: Any, user_tokens: Optional[Iterable[str]] = None) -> np.ndarray:
+    """Determine the internal user ids to evaluate for top-k export."""
+
+    if user_tokens:
+        resolved = []
+        missing = []
+        for token in user_tokens:
+            internal = _resolve_user_token(dataset, token)
+            if internal is None:
+                missing.append(token)
+            else:
+                resolved.append(internal)
+        if missing:
+            preview = ", ".join(map(str, missing[:5]))
+            logging.warning(
+                "Skipping %d unknown user_id token(s) from subset: %s%s",
+                len(missing),
+                preview,
+                "…" if len(missing) > 5 else "",
+            )
+        if not resolved:
+            return np.array([], dtype=np.int64)
+        return np.unique(np.asarray(resolved, dtype=np.int64))
+
+    uid_field = dataset.uid_field
+    eval_dataset = getattr(test_data, "dataset", None) or getattr(test_data, "_dataset", None)
+    if eval_dataset is None:
+        raise ValueError("Unable to derive evaluation dataset for top-k export.")
+    user_array = eval_dataset.inter_feat[uid_field].numpy()
+    return np.unique(user_array.astype(np.int64, copy=False))
+
+
+def export_topk_recs(
+    *,
+    trainer: Any,
+    dataset: Any,
+    test_data: Any,
+    k: int,
+    output_file: Path,
+    user_tokens: Optional[Iterable[str]] = None,
+) -> Optional[Path]:
+    """Write top-``k`` recommendations per user to ``output_file``.
+
+    Returns the path when export succeeds and ``None`` when no users were available.
+    """
+
+    if full_sort_topk is None:  # pragma: no cover - triggered only when RecBole missing.
+        raise RuntimeError(
+            "RecBole utilities are required for top-k export. Install recbole to proceed."
+        )
+    if k <= 0:
+        return None
+
+    user_ids = _resolve_user_ids(dataset, test_data, user_tokens)
+    if user_ids.size == 0:
+        logging.warning("Top-%d export skipped because no users were available", k)
+        return None
+
+    max_items = max(int(dataset.item_num) - 1, 1)
+    effective_k = min(k, max_items)
+    if effective_k != k:
+        logging.warning(
+            "Requested top-%d recommendations but only %d items are available; using top-%d instead",
+            k,
+            max_items,
+            effective_k,
+        )
+
+    device = getattr(trainer, "device", None)
+    scores, indices = full_sort_topk(user_ids, trainer.model, test_data, effective_k, device=device)
+    scores = scores.cpu().numpy()
+    indices = indices.cpu().numpy()
+
+    uid_field = dataset.uid_field
+    iid_field = dataset.iid_field
+    user_tokens_resolved = np.asarray(dataset.id2token(uid_field, user_ids)).tolist()
+    item_tokens = dataset.id2token(iid_field, indices)
+    item_tokens = np.asarray(item_tokens)
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with output_file.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["user_id", "item_id", "rank", "score"])
+        for user_token, user_items, user_scores in zip(
+            user_tokens_resolved, item_tokens, scores, strict=True
+        ):
+            for rank, (item_token, score) in enumerate(zip(user_items, user_scores, strict=True), start=1):
+                writer.writerow([str(user_token), str(item_token), rank, float(score)])
+
+    logging.info("Wrote %s (users=%d, k=%d)", output_file, len(user_tokens_resolved), effective_k)
+    return output_file
+
+
+def _run_recbole_training(
+    *,
+    model: str,
+    dataset: str,
+    config_file_list: Optional[Sequence[str]],
+    config_dict: Dict[str, object],
+) -> TrainingRun:
+    """Execute the RecBole training loop and capture its artifacts."""
+
+    if Config is None:  # pragma: no cover - triggered only when RecBole missing.
+        raise RuntimeError(
+            "RecBole is required to train the model. Install it with `pip install recbole`."
+        ) from _IMPORT_ERROR
+
+    config = Config(
+        model=model,
+        dataset=dataset,
+        config_file_list=config_file_list,
+        config_dict=config_dict,
+    )
+    init_seed(config["seed"], config["reproducibility"])
+    init_logger(config)
+    logger = logging.getLogger()
+    logger.info(sys.argv)
+    logger.info(config)
+
+    dataset_obj = create_dataset(config)
+    logger.info(dataset_obj)
+
+    train_data, valid_data, test_data = data_preparation(config, dataset_obj)
+
+    init_seed(config["seed"] + config["local_rank"], config["reproducibility"])
+    model_class = get_model(config["model"])
+    model_obj = model_class(config, train_data._dataset).to(config["device"])
+    logger.info(model_obj)
+
+    transform = construct_transform(config)
+    flops = get_flops(model_obj, dataset_obj, config["device"], logger, transform)
+    logger.info(set_color("FLOPs", "blue") + f": {flops}")
+
+    trainer_class = get_trainer(config["MODEL_TYPE"], config["model"])
+    trainer = trainer_class(config, model_obj)
+
+    best_valid_score, best_valid_result = trainer.fit(
+        train_data,
+        valid_data,
+        saved=True,
+        show_progress=config["show_progress"],
+    )
+
+    test_result = trainer.evaluate(
+        test_data,
+        load_best_model=True,
+        show_progress=config["show_progress"],
+    )
+
+    environment_tb = get_environment(config)
+    logger.info(
+        "The running environment of this training is as follows:\n" + environment_tb.draw()
+    )
+
+    logger.info(set_color("best valid ", "yellow") + f": {best_valid_result}")
+    logger.info(set_color("test result", "yellow") + f": {test_result}")
+
+    result = {
+        "best_valid_score": best_valid_score,
+        "valid_score_bigger": config["valid_metric_bigger"],
+        "best_valid_result": best_valid_result,
+        "test_result": test_result,
+    }
+
+    if not config["single_spec"]:
+        dist.destroy_process_group()
+
+    return TrainingRun(
+        result=result,
+        config=config,
+        dataset=dataset_obj,
+        train_data=train_data,
+        valid_data=valid_data,
+        test_data=test_data,
+        trainer=trainer,
+    )
 
 
 def train_model(
@@ -68,10 +367,10 @@ def train_model(
     device: Optional[str] = None,
     max_seq_length: Optional[int] = None,
     extra_config: Optional[Dict[str, object]] = None,
-) -> Dict[str, object]:
-    """Launch a RecBole training run and return its reported metrics."""
+) -> TrainingRun:
+    """Launch a RecBole training run and return the resulting artifacts."""
 
-    if run_recbole is None:  # pragma: no cover - triggered only when dependency missing.
+    if Config is None:  # pragma: no cover - triggered only when dependency missing.
         raise RuntimeError(
             "RecBole is required to train the model. Install it with `pip install recbole`."
         ) from _IMPORT_ERROR
@@ -136,16 +435,20 @@ def train_model(
         dataset,
         json.dumps(overrides, indent=2, sort_keys=True),
     )
-    result = run_recbole(  # type: ignore[misc]
+    training_run = _run_recbole_training(
         model=model,
         dataset=dataset,
         config_file_list=config_files,
         config_dict=overrides,
     )
-    logging.info("Training finished. Best validation metric: %s", result.get("best_valid_score"))
+    result = training_run.result
+    logging.info(
+        "Training finished. Best validation metric: %s",
+        result.get("best_valid_score"),
+    )
     logging.info("Validation result: %s", result.get("valid_result"))
     logging.info("Test result: %s", result.get("test_result"))
-    return result
+    return training_run
 
 
 def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
@@ -193,6 +496,24 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Override MAX_ITEM_LIST_LENGTH for SASRec.",
     )
     parser.add_argument(
+        "--export-topk",
+        type=int,
+        default=0,
+        help="Export top-K recommendations after training (0 disables).",
+    )
+    parser.add_argument(
+        "--export-topk-users",
+        type=Path,
+        default=None,
+        help="Optional CSV listing user_id tokens to restrict the export.",
+    )
+    parser.add_argument(
+        "--export-topk-file",
+        type=Path,
+        default=Path("saved/topk_recs.csv"),
+        help="Destination CSV for exported recommendations (default: saved/topk_recs.csv).",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         help="Python logging level (default: INFO).",
@@ -208,7 +529,7 @@ def main(argv: Optional[Sequence[str]] = None) -> Dict[str, object]:
     if args.config_file and not args.config_file.exists():
         logging.warning("Config file %s does not exist; relying solely on CLI overrides", args.config_file)
 
-    result = train_model(
+    training_run = train_model(
         dataset=args.dataset_name,
         data_path=args.data_path,
         config_file=config_file,
@@ -222,7 +543,32 @@ def main(argv: Optional[Sequence[str]] = None) -> Dict[str, object]:
         device=args.device,
         max_seq_length=args.max_seq_length,
     )
-    return result
+    if args.export_topk > 0 and _is_rank_zero():
+        user_tokens: Optional[Sequence[str]] = None
+        if args.export_topk_users:
+            if args.export_topk_users.exists():
+                user_tokens = _load_user_tokens(args.export_topk_users)
+                logging.info(
+                    "Loaded %d user_id token(s) from %s for top-%d export",
+                    len(user_tokens),
+                    args.export_topk_users,
+                    args.export_topk,
+                )
+            else:
+                logging.warning(
+                    "User subset file %s not found; exporting recommendations for all users",
+                    args.export_topk_users,
+                )
+
+        export_topk_recs(
+            trainer=training_run.trainer,
+            dataset=training_run.dataset,
+            test_data=training_run.test_data,
+            k=args.export_topk,
+            output_file=args.export_topk_file,
+            user_tokens=user_tokens,
+        )
+    return training_run.result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the quick_start helper with an inline RecBole training routine that returns the dataset, dataloaders, trainer, and metrics
- add helpers to parse user subsets and export top-K recommendations via RecBole's `full_sort_topk`
- expose new CLI flags that trigger the export step after training and log the generated CSV path

## Testing
- python -m compileall kuairec_pipeline/train_sasrec.py

------
https://chatgpt.com/codex/tasks/task_e_68d178bda8c08326af64bdc2aeb083a5